### PR TITLE
Use relative paths in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Sam Phippen <samphippen@googlemail.com>"]
 
 [dependencies]
-descriptor = {path = "/Users/sam/dev/descriptor"}
+descriptor = { path = "../descriptor" }


### PR DESCRIPTION
It's worth noting that if you publish an empty crate to crates.io, you
can override the version locally with a path
(http://doc.crates.io/config.html). Assuming you don't want to ship
0.0.1, though, let's at least use a relative path here, so other people
can compile this thing. :)
