### PR TITLE
Add GitHub URL to Descriptor dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Sam Phippen <samphippen@googlemail.com>"]
 
 [dependencies]
-descriptor = { path = "../descriptor" }
+expector = { git = "https://github.com/samphippen/descriptor" }


### PR DESCRIPTION
I might be misunderstanding the intention here, so feel free to close these 2 PRs if they don't make sense, but currently both `descriptor` and `expector` are trying to find each other somewhere in the local filesystem. This means that in order to use either one, you would need to have both cloned. My thinking is that if it makes sense to have `descriptor` and `expector` in separate repos, then it also presumably makes sense to have one work without the other being cloned. Let me know what you think.

Counterpart of https://github.com/samphippen/descriptor/pull/3
